### PR TITLE
See https://github.com/quri/react-bootstrap-datetimepicker/issues/111…

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "babel-runtime": "^5.6.18",
     "classnames": "^2.1.2",
     "eonasdan-bootstrap-datetimepicker": "^4.15.35",
-    "moment": "^2.8.2",
-    "react-bootstrap": "^0.16.1"
+    "moment": "^2.8.2"
   }
 }


### PR DESCRIPTION
…, shouldn't need react-bbotstrap dep with Gylphicons removed already
